### PR TITLE
chore(borgctl): also search shini in ${INSTALLDIR}

### DIFF
--- a/adds/borgctl
+++ b/adds/borgctl
@@ -72,7 +72,7 @@ usage() {
 
 # check installation of shini
 SHINI=""
-pathes=(/bin /usr/bin ${HOME}/bin ${HOME}/usr/bin ${INSTALLDIR}/../misc/shini)
+pathes=(/bin /usr/bin ${HOME}/bin ${HOME}/usr/bin ${INSTALLDIR}/../misc/shini ${INSTALLDIR})
 for path in ${pathes[@]}; do
 	[[ -f ${path}/shini.sh ]] && SHINI=${path}/shini.sh && break
 	[[ -f ${path}/shini ]] && SHINI=${path}/shini && break


### PR DESCRIPTION
Current README does not work due to shini not being found in the current folder.

```
docker run --rm silviof/docker-borgbackup get_borgctl > borgctl
docker run --rm silviof/docker-borgbackup get_ini > borgbackup.ini
docker run --rm silviof/docker-borgbackup get_shini > shini
chmod u+x borgctl
```
